### PR TITLE
 Smart::Options::DeclareでMultipleを指定し実際の引数なしのときの警告をなくす

### DIFF
--- a/lib/Smart/Options/Declare.pm
+++ b/lib/Smart/Options/Declare.pm
@@ -12,13 +12,17 @@ our $COERCE = {
     Multiple => {
         type      => 'ArrayRef',
         generater => sub {
-            [
-                split(
-                    qr{,},
-                    ref( $_[0] ) eq 'ARRAY' ? join( q{,}, @{ $_[0] } ) : $_[0]
-                )
-            ];
-          }
+            if ( defined $_[0] ) {
+                return [
+                    split(
+                        qr{,},
+                        ref( $_[0] ) eq 'ARRAY' ? join( q{,}, @{ $_[0] } ) : $_[0]
+                    )
+                ];
+            } else {
+                return $_[0];
+            }
+        }
     }
 };
 my %is_invocant = map{ $_ => undef } qw($self $class);


### PR DESCRIPTION
コミットメッセージの英語が良くわからんん感じになったので、日本語送ります。。。

```
# hoge.pl
use Smart::Options::Declare;
opts my $ids => 'Multiple';
```

ってコードに書いて、

```
perl hoge.pl
```

と引数指定せずにたたいちゃうと、

> Use of uninitialized value in split at /home/qoop/perl5/perlbrew/perls/perl-5.10.1/lib/site_perl/5.10.1/Smart/Options/Declare.pm line 18.

って出ちゃうんですが、これって想定外ですよね？問題なければ取り込んでもらえると助かりますー。
